### PR TITLE
VLCPlayerViewControllerDelegate to expose events from VLCMediaPlayer

### DIFF
--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -31,19 +31,19 @@ class ViewController: UIViewController {
 }
 
 extension ViewController: VLCMediaPlayerViewControllerDelegate {
-    func mediaPlayer(_ player: VLCPlayerViewController, stateChanged state: VLCMediaPlayerState) {
+    func mediaPlayer(_ playerViewController: VLCPlayerViewController, stateChanged state: VLCMediaPlayerState) {
         print("State changed: \(state.rawValue)")
     }
     
-    func mediaPlayer(_ player: VLCPlayerViewController, timeChanged time: VLCTime) {
+    func mediaPlayer(_ playerViewController: VLCPlayerViewController, timeChanged time: VLCTime) {
         print("Time changed: \(time)")
     }
     
-    func mediaPlayer(_ player: VLCPlayerViewController, titleChanged name: String, duration: Int, isMenu: Bool) {
+    func mediaPlayer(_ playerViewController: VLCPlayerViewController, titleChanged name: String, duration: Int, isMenu: Bool) {
         print("Title changed: \(name)")
     }
     
-    func mediaPlayer(_ player: VLCPlayerViewController, chapterChanged name: String, timeOffset: Int, duration: Int) {
+    func mediaPlayer(_ playerViewController: VLCPlayerViewController, chapterChanged name: String, timeOffset: Int, duration: Int) {
         print("Chapter changed: \(name)")
     }
 }

--- a/Demo/Demo/ViewController.swift
+++ b/Demo/Demo/ViewController.swift
@@ -25,7 +25,25 @@ class ViewController: UIViewController {
         if let playerVC = segue.destination as? VLCPlayerViewController {
             let media = VLCMedia(url: demoVideoURL)
             playerVC.media = media
+            playerVC.delegate = self
         }
     }
 }
 
+extension ViewController: VLCMediaPlayerViewControllerDelegate {
+    func mediaPlayer(_ player: VLCPlayerViewController, stateChanged state: VLCMediaPlayerState) {
+        print("State changed: \(state.rawValue)")
+    }
+    
+    func mediaPlayer(_ player: VLCPlayerViewController, timeChanged time: VLCTime) {
+        print("Time changed: \(time)")
+    }
+    
+    func mediaPlayer(_ player: VLCPlayerViewController, titleChanged name: String, duration: Int, isMenu: Bool) {
+        print("Title changed: \(name)")
+    }
+    
+    func mediaPlayer(_ player: VLCPlayerViewController, chapterChanged name: String, timeOffset: Int, duration: Int) {
+        print("Chapter changed: \(name)")
+    }
+}

--- a/Sources/VLCMediaPlayerViewControllerDelegate.swift
+++ b/Sources/VLCMediaPlayerViewControllerDelegate.swift
@@ -1,0 +1,35 @@
+//
+//  VLCMediaPlayerViewControllerDelegate.swift
+//  TVVLCPlayer
+//
+//  Created by Zhang, Weiran on 04/04/2018.
+//
+
+public protocol VLCMediaPlayerViewControllerDelegate {
+    /**
+     * Called whenever the player's state has changed.
+     */
+    func mediaPlayerStateChanged(state: VLCMediaPlayerState)
+    
+    /**
+     * Called whenever the player's time has changed.
+     */
+    func mediaPlayerTimeChanged(time: VLCTime)
+    
+    /**
+     * Called whenever the player's title has changed (if any).
+     */
+    func mediaPlayerTitleChanged(name: String, duration: Int, isMenu: Bool)
+    
+    /**
+     * Called whenever the player's chapter has changed (if any).
+     */
+    func mediaPlayerChapterChanged(name: String, timeOffset: Int, duration: Int)
+}
+
+extension VLCMediaPlayerViewControllerDelegate {
+    func mediaPlayerStateChanged(state: VLCMediaPlayerState) {}
+    func mediaPlayerTimeChanged(state: VLCMediaPlayerState) {}
+    func mediaPlayerTitleChanged(state: VLCMediaPlayerState) {}
+    func mediaPlayerChapterChanged(state: VLCMediaPlayerState) {}
+}

--- a/Sources/VLCMediaPlayerViewControllerDelegate.swift
+++ b/Sources/VLCMediaPlayerViewControllerDelegate.swift
@@ -5,31 +5,24 @@
 //  Created by Zhang, Weiran on 04/04/2018.
 //
 
-public protocol VLCMediaPlayerViewControllerDelegate {
+@objc public protocol VLCMediaPlayerViewControllerDelegate {
     /**
      * Called whenever the player's state has changed.
      */
-    func mediaPlayer(_ player: VLCPlayerViewController, stateChanged state: VLCMediaPlayerState)
+    @objc optional func mediaPlayer(_ player: VLCPlayerViewController, stateChanged state: VLCMediaPlayerState)
     
     /**
      * Called whenever the player's time has changed.
      */
-    func mediaPlayer(_ player: VLCPlayerViewController, timeChanged time: VLCTime)
+    @objc optional func mediaPlayer(_ player: VLCPlayerViewController, timeChanged time: VLCTime)
     
     /**
      * Called whenever the player's title has changed (if any).
      */
-    func mediaPlayer(_ player: VLCPlayerViewController, titleChanged name: String, duration: Int, isMenu: Bool)
+    @objc optional func mediaPlayer(_ player: VLCPlayerViewController, titleChanged name: String, duration: Int, isMenu: Bool)
     
     /**
      * Called whenever the player's chapter has changed (if any).
      */
-    func mediaPlayer(_ player: VLCPlayerViewController, chapterChanged name: String, timeOffset: Int, duration: Int)
-}
-
-extension VLCMediaPlayerViewControllerDelegate {
-    func mediaPlayer(_ player: VLCPlayerViewController, stateChanged state: VLCMediaPlayerState) {}
-    func mediaPlayer(_ player: VLCPlayerViewController, timeChanged time: VLCTime) {}
-    func mediaPlayer(_ player: VLCPlayerViewController, titleChanged name: String, duration: Int, isMenu: Bool) {}
-    func mediaPlayer(_ player: VLCPlayerViewController, chapterChanged name: String, timeOffset: Int, duration: Int) {}
+    @objc optional func mediaPlayer(_ player: VLCPlayerViewController, chapterChanged name: String, timeOffset: Int, duration: Int)
 }

--- a/Sources/VLCMediaPlayerViewControllerDelegate.swift
+++ b/Sources/VLCMediaPlayerViewControllerDelegate.swift
@@ -9,20 +9,20 @@
     /**
      * Called whenever the player's state has changed.
      */
-    @objc optional func mediaPlayer(_ player: VLCPlayerViewController, stateChanged state: VLCMediaPlayerState)
+    @objc optional func mediaPlayer(_ playerViewController: VLCPlayerViewController, stateChanged state: VLCMediaPlayerState)
     
     /**
      * Called whenever the player's time has changed.
      */
-    @objc optional func mediaPlayer(_ player: VLCPlayerViewController, timeChanged time: VLCTime)
+    @objc optional func mediaPlayer(_ playerViewController: VLCPlayerViewController, timeChanged time: VLCTime)
     
     /**
      * Called whenever the player's title has changed (if any).
      */
-    @objc optional func mediaPlayer(_ player: VLCPlayerViewController, titleChanged name: String, duration: Int, isMenu: Bool)
+    @objc optional func mediaPlayer(_ playerViewController: VLCPlayerViewController, titleChanged name: String, duration: Int, isMenu: Bool)
     
     /**
      * Called whenever the player's chapter has changed (if any).
      */
-    @objc optional func mediaPlayer(_ player: VLCPlayerViewController, chapterChanged name: String, timeOffset: Int, duration: Int)
+    @objc optional func mediaPlayer(_ playerViewController: VLCPlayerViewController, chapterChanged name: String, timeOffset: Int, duration: Int)
 }

--- a/Sources/VLCMediaPlayerViewControllerDelegate.swift
+++ b/Sources/VLCMediaPlayerViewControllerDelegate.swift
@@ -9,27 +9,27 @@ public protocol VLCMediaPlayerViewControllerDelegate {
     /**
      * Called whenever the player's state has changed.
      */
-    func mediaPlayerStateChanged(state: VLCMediaPlayerState)
+    func mediaPlayer(_ player: VLCPlayerViewController, stateChanged state: VLCMediaPlayerState)
     
     /**
      * Called whenever the player's time has changed.
      */
-    func mediaPlayerTimeChanged(time: VLCTime)
+    func mediaPlayer(_ player: VLCPlayerViewController, timeChanged time: VLCTime)
     
     /**
      * Called whenever the player's title has changed (if any).
      */
-    func mediaPlayerTitleChanged(name: String, duration: Int, isMenu: Bool)
+    func mediaPlayer(_ player: VLCPlayerViewController, titleChanged name: String, duration: Int, isMenu: Bool)
     
     /**
      * Called whenever the player's chapter has changed (if any).
      */
-    func mediaPlayerChapterChanged(name: String, timeOffset: Int, duration: Int)
+    func mediaPlayer(_ player: VLCPlayerViewController, chapterChanged name: String, timeOffset: Int, duration: Int)
 }
 
 extension VLCMediaPlayerViewControllerDelegate {
-    func mediaPlayerStateChanged(state: VLCMediaPlayerState) {}
-    func mediaPlayerTimeChanged(state: VLCMediaPlayerState) {}
-    func mediaPlayerTitleChanged(state: VLCMediaPlayerState) {}
-    func mediaPlayerChapterChanged(state: VLCMediaPlayerState) {}
+    func mediaPlayer(_ player: VLCPlayerViewController, stateChanged state: VLCMediaPlayerState) {}
+    func mediaPlayer(_ player: VLCPlayerViewController, timeChanged time: VLCTime) {}
+    func mediaPlayer(_ player: VLCPlayerViewController, titleChanged name: String, duration: Int, isMenu: Bool) {}
+    func mediaPlayer(_ player: VLCPlayerViewController, chapterChanged name: String, timeOffset: Int, duration: Int) {}
 }

--- a/Sources/VLCPlayerViewController.swift
+++ b/Sources/VLCPlayerViewController.swift
@@ -249,6 +249,8 @@ extension VLCPlayerViewController: VLCMediaPlayerDelegate {
         if player.state == .ended || player.state == .error || player.state == .stopped {
             dismiss(animated: true)
         }
+        
+        delegate?.mediaPlayerStateChanged(state: player.state)
     }
     
     public func mediaPlayerTimeChanged(_ aNotification: Notification!) {
@@ -256,6 +258,41 @@ extension VLCPlayerViewController: VLCMediaPlayerDelegate {
         isBuffering = false
 
         updateViews(with: player.time)
+        
+        delegate?.mediaPlayerTimeChanged(time: player.time)
+    }
+    
+    public func mediaPlayerTitleChanged(_ aNotification: Notification!) {
+        guard let titleDescriptions = player.titleDescriptions,
+            player.currentTitleIndex != NSNotFound,
+            let titleDescription = titleDescriptions[Int(player.currentTitleIndex)] as? [String: Any] else {
+                return
+        }
+        
+        guard let name = titleDescription[VLCTitleDescriptionName] as? String,
+            let duration = titleDescription[VLCTitleDescriptionDuration] as? Int,
+            let isMenu = titleDescription[VLCTitleDescriptionIsMenu] as? Bool else {
+            return
+        }
+        
+        delegate?.mediaPlayerTitleChanged(name: name, duration: duration, isMenu: isMenu)
+    }
+    
+    public func mediaPlayerChapterChanged(_ aNotification: Notification!) {
+        guard player.currentChapterIndex != NSNotFound,
+            player.currentTitleIndex != NSNotFound,
+            let chapterDescriptions = player.chapterDescriptions(ofTitle: player.currentTitleIndex),
+        let chapterDescription = chapterDescriptions[Int(player.currentChapterIndex)] as? [String: Any] else {
+                return
+        }
+        
+        guard let name = chapterDescription[VLCChapterDescriptionName] as? String,
+            let duration = chapterDescription[VLCChapterDescriptionDuration] as? Int,
+            let timeOffset = chapterDescription[VLCChapterDescriptionTimeOffset] as? Int else {
+                return
+        }
+
+        delegate?.mediaPlayerChapterChanged(name: name, timeOffset: timeOffset, duration: duration)
     }
 }
 

--- a/Sources/VLCPlayerViewController.swift
+++ b/Sources/VLCPlayerViewController.swift
@@ -252,7 +252,7 @@ extension VLCPlayerViewController: VLCMediaPlayerDelegate {
             dismiss(animated: true)
         }
         
-        delegate?.mediaPlayer(self, stateChanged: player.state)
+        delegate?.mediaPlayer?(self, stateChanged: player.state)
     }
     
     public func mediaPlayerTimeChanged(_ aNotification: Notification!) {
@@ -261,7 +261,7 @@ extension VLCPlayerViewController: VLCMediaPlayerDelegate {
 
         updateViews(with: player.time)
         
-        delegate?.mediaPlayer(self, timeChanged: player.time)
+        delegate?.mediaPlayer?(self, timeChanged: player.time)
     }
     
     public func mediaPlayerTitleChanged(_ aNotification: Notification!) {
@@ -277,7 +277,7 @@ extension VLCPlayerViewController: VLCMediaPlayerDelegate {
             return
         }
         
-        delegate?.mediaPlayer(self, titleChanged: name, duration: duration, isMenu: isMenu)
+        delegate?.mediaPlayer?(self, titleChanged: name, duration: duration, isMenu: isMenu)
     }
     
     public func mediaPlayerChapterChanged(_ aNotification: Notification!) {
@@ -294,7 +294,7 @@ extension VLCPlayerViewController: VLCMediaPlayerDelegate {
                 return
         }
 
-        delegate?.mediaPlayer(self, chapterChanged: name, timeOffset: timeOffset, duration: duration)
+        delegate?.mediaPlayer?(self, chapterChanged: name, timeOffset: timeOffset, duration: duration)
     }
 }
 

--- a/Sources/VLCPlayerViewController.swift
+++ b/Sources/VLCPlayerViewController.swift
@@ -82,6 +82,8 @@ public class VLCPlayerViewController: UIViewController {
     
     public let player = VLCMediaPlayer()
     
+    public var delegate: VLCMediaPlayerViewControllerDelegate?
+    
     public override var preferredUserInterfaceStyle: UIUserInterfaceStyle {
         return .dark
     }
@@ -250,7 +252,7 @@ extension VLCPlayerViewController: VLCMediaPlayerDelegate {
             dismiss(animated: true)
         }
         
-        delegate?.mediaPlayer(player: self, stateChanged: player.state)
+        delegate?.mediaPlayer(self, stateChanged: player.state)
     }
     
     public func mediaPlayerTimeChanged(_ aNotification: Notification!) {
@@ -259,7 +261,7 @@ extension VLCPlayerViewController: VLCMediaPlayerDelegate {
 
         updateViews(with: player.time)
         
-        delegate?.mediaPlayer(player: self, timeChanged: player.time)
+        delegate?.mediaPlayer(self, timeChanged: player.time)
     }
     
     public func mediaPlayerTitleChanged(_ aNotification: Notification!) {

--- a/Sources/VLCPlayerViewController.swift
+++ b/Sources/VLCPlayerViewController.swift
@@ -250,7 +250,7 @@ extension VLCPlayerViewController: VLCMediaPlayerDelegate {
             dismiss(animated: true)
         }
         
-        delegate?.mediaPlayerStateChanged(state: player.state)
+        delegate?.mediaPlayer(player: self, stateChanged: player.state)
     }
     
     public func mediaPlayerTimeChanged(_ aNotification: Notification!) {
@@ -259,7 +259,7 @@ extension VLCPlayerViewController: VLCMediaPlayerDelegate {
 
         updateViews(with: player.time)
         
-        delegate?.mediaPlayerTimeChanged(time: player.time)
+        delegate?.mediaPlayer(player: self, timeChanged: player.time)
     }
     
     public func mediaPlayerTitleChanged(_ aNotification: Notification!) {
@@ -275,7 +275,7 @@ extension VLCPlayerViewController: VLCMediaPlayerDelegate {
             return
         }
         
-        delegate?.mediaPlayerTitleChanged(name: name, duration: duration, isMenu: isMenu)
+        delegate?.mediaPlayer(self, titleChanged: name, duration: duration, isMenu: isMenu)
     }
     
     public func mediaPlayerChapterChanged(_ aNotification: Notification!) {
@@ -292,7 +292,7 @@ extension VLCPlayerViewController: VLCMediaPlayerDelegate {
                 return
         }
 
-        delegate?.mediaPlayerChapterChanged(name: name, timeOffset: timeOffset, duration: duration)
+        delegate?.mediaPlayer(self, chapterChanged: name, timeOffset: timeOffset, duration: duration)
     }
 }
 


### PR DESCRIPTION
I sometimes need to use `VLCMediaPlayer`'s delegate to react to certain events. I wasn't sure if you wanted to encapsulate those events in your own protocol, or just forward on `VLCMediaPlayer`'s delegate, so I've gone with the easiest option for now and am open to discussion.