### PR TITLE
Fixed openingIndicator always showing

### DIFF
--- a/Sources/VLCPlayerViewController.swift
+++ b/Sources/VLCPlayerViewController.swift
@@ -73,16 +73,17 @@ public class VLCPlayerViewController: UIViewController {
             guard self.viewIfLoaded != nil else {
                 return
             }
+            
+            if isOpening && !openingIndicator.isAnimating {
+                openingIndicator.startAnimating()
+            } else if !isOpening && openingIndicator.isAnimating {
+                openingIndicator.stopAnimating()
+            }
 
             guard isOpening != oldValue else {
                 return
             }
 
-            if isOpening {
-                openingIndicator.startAnimating()
-            } else {
-                openingIndicator.stopAnimating()
-            }
             self.setUpPositionController()
         }
     }


### PR DESCRIPTION
There is a condition where isOpening is false, but the openingIndicator would still be animating. This now starts/stops animations every time isOpening is set (whether the value has changed or not), with additional checks.